### PR TITLE
Fix path mapping for querystrings

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -27,7 +27,8 @@ const getEndpoint = (endpoints, req) => endpoints
       pathRegex = `^${pathRegex}$` // We expect an exact match for the url
     }
 
-    return new RegExp(pathRegex).test(req.url)
+    const reqUrl = req.url.split('?')[0]
+    return new RegExp(pathRegex).test(reqUrl)
   })
 
 const toExpressPath = (path) => path

--- a/lib/router.test.js
+++ b/lib/router.test.js
@@ -212,6 +212,27 @@ describe('router', () => {
 
       expect(endpoint).toEqual(matchEndpoint)
     })
+
+    it('should ignore query when matching path', () => {
+      const matchEndpoint = {
+        http: {
+          path: '/test/path',
+          method: 'get',
+          cors: null,
+        },
+      }
+
+      const endpoints = [matchEndpoint]
+
+      const req = {
+        method: 'GET',
+        url: '/test/path?query=abc',
+      }
+
+      const endpoint = router.getEndpoint(endpoints, req)
+
+      expect(endpoint).toEqual(matchEndpoint)
+    })
   })
 
   describe('toExpressPath', () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/gertjvr/serverless-plugin-simulate/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #61

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Split the `req.url` on `'?'` and only match on the first element in the array

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

I have added a unit test that verifies that querystrings pass

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES