### PR TITLE
Implement project name / docker network support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,20 @@ provider:
 # this is optional configurations
 # servicesPathDest is use for the case u want to compile all your src and out
 # put to another folder like dist
+#
+# services allows specifying a docker-compose.yml file and (optional)
+# projectName. This will start the docker-compose stack when simulate is run.
+# If projectName is specified, it will be used when running docker-compose,
+# and the default docker-compose network will be passed to lambda docker commands
+# allowing all lambdas to access any hosts defined in docker-compose services
 custom:
   simulate:
     dist: dist
-    services: docker-compose.yml
+    services:
+      file: docker-compose.yml
+      # will use: $ docker-compose --project-name myproject ...
+      # and:      $ docker --network myproject_default ...
+      projectName: myproject
 
 plugins:
   - serverless-plugin-simulate

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,16 +4,23 @@ const velocityDefaults = require('./integration/velocity/defaults')
 
 const JSON_CONTENT_TYPE = 'application/json'
 
+const normalizeProjectName = (name) => name && name.toLowerCase().replace(/[^a-z0-9]/g, '')
+
 const getFunctionConfig = (serverless, functionName, functionConfig) => {
   const servicePath = serverless.config.servicePath
   const serviceName = serverless.service.service
   const provider = serverless.service.provider
   const stage = provider.stage
+  const projectName = serverless.service.custom &&
+    serverless.service.custom.simulate &&
+    serverless.service.custom.simulate.services &&
+    serverless.service.custom.simulate.services.projectName
 
   return Object.freeze({
     key: `${serviceName}-${stage}-${functionName}`,
     serviceName,
     servicePath,
+    projectName: normalizeProjectName(projectName),
     region: provider.region,
     stage,
     functionName,
@@ -255,6 +262,7 @@ const getMockServices = (serverless, file, host) => {
   return {
     file: options.file || file,
     host: options.host || host,
+    projectName: normalizeProjectName(options.projectName),
   }
 }
 

--- a/lib/config.test.js
+++ b/lib/config.test.js
@@ -81,6 +81,33 @@ describe('config', () => {
     })
 
     it('should get function config', () => {
+      serverless.service.custom = {
+        simulate: {
+          services: {
+            projectName: 'test-project',
+          },
+        },
+      }
+
+      const functionConfig = config.getFunctionConfig(serverless, 'test-func')
+
+      expect(functionConfig).toEqual({
+        key: 'test-service-test-test-func',
+        serviceName: 'test-service',
+        functionName: 'test-func',
+        region: 'us-east-1',
+        stage: 'test',
+        servicePath: '/test/file/path',
+        handler: 'index.endpoint',
+        memorySize: 512,
+        timeout: 3,
+        runtime: 'nodejs4.3',
+        environment: {},
+        projectName: 'testproject',
+      })
+    })
+
+    it('should get function config with project name', () => {
       const functionConfig = config.getFunctionConfig(serverless, 'test-func')
 
       expect(functionConfig).toEqual({
@@ -469,6 +496,60 @@ describe('config', () => {
       expect(mockConfig).toEqual({
         file: 'docker-compose.yml',
         host: 'host',
+      })
+    })
+
+    it('should get mock services config from custom with project name', () => {
+      const serverless = {
+        config: {
+          servicePath: '/test/file/path',
+        },
+        service: {
+          service: 'test-service',
+          provider: {},
+          custom: {
+            simulate: {
+              services: {
+                file: 'docker-compose1.yml',
+                projectName: 'test',
+              },
+            },
+          },
+        },
+      }
+
+      const mockConfig = config.getMockServices(serverless)
+
+      expect(mockConfig).toEqual({
+        file: 'docker-compose1.yml',
+        projectName: 'test',
+      })
+    })
+
+    it('should get mock services config from custom with normalized project name', () => {
+      const serverless = {
+        config: {
+          servicePath: '/test/file/path',
+        },
+        service: {
+          service: 'test-service',
+          provider: {},
+          custom: {
+            simulate: {
+              services: {
+                file: 'docker-compose1.yml',
+                projectName: 'TEST_-123',
+              },
+            },
+          },
+        },
+      }
+
+      const mockConfig = config.getMockServices(serverless)
+
+      expect(mockConfig).toEqual({
+        file: 'docker-compose1.yml',
+        projectName: 'test123',
       })
     })
   })

--- a/lib/invoke/local.js
+++ b/lib/invoke/local.js
@@ -17,6 +17,12 @@ const invoke = (func, event, lambdaEndpoint, logger) => {
     '-m', `${memorySize}M`,
   ]
 
+  const network = func.projectName ? `${func.projectName}_default` : ''
+  if (network) {
+    dockerArgs.push('--network')
+    dockerArgs.push(network)
+  }
+
   const simulateEnvironment = {
     AWS_LAMBDA_FUNCTION_NAME: func.key,
     AWS_LAMBDA_FUNCTION_MEMORY_SIZE: memorySize,

--- a/lib/invoke/local.test.js
+++ b/lib/invoke/local.test.js
@@ -65,6 +65,60 @@ describe('local-invoke', () => {
     })
   })
 
+  it('should invoke run with network', () => {
+    const funcConfig = {
+      runtime: 'node4.3',
+      servicePath: '/test/path',
+      handler: 'index.handler',
+      memorySize: 512,
+      timeout: 10,
+      region: 'us-east-1',
+      environment: {},
+      stage: 'test',
+      key: 'test-service-test-test-func',
+      projectName: 'testproject',
+    }
+    const event = {}
+
+    const result = {
+      stdout: '{ "message": "saved" }',
+    }
+
+    mockRun.mockImplementation(() => BbPromise.resolve(result))
+
+    const lambda = lambdaLocal()
+
+    return lambda
+    .invoke(funcConfig, event)
+    .then((actual) => {
+      expect(mockRun.mock.calls.length).toBe(1)
+      expect(mockRun.mock.calls[0][0]).toEqual({
+        addEnvVars: true,
+        handler: funcConfig.handler,
+        event,
+        taskDir: funcConfig.servicePath,
+        cleanUp: true,
+        returnSpawnResult: true,
+        dockerImage: 'lambci/lambda:node4.3',
+        dockerArgs: [
+          '-m', '512M',
+          '--network', 'testproject_default',
+          '-e', 'AWS_LAMBDA_FUNCTION_NAME=test-service-test-test-func',
+          '-e', 'AWS_LAMBDA_FUNCTION_MEMORY_SIZE=512',
+          '-e', 'AWS_LAMBDA_FUNCTION_TIMEOUT=10',
+          '-e', 'AWS_LAMBDA_LOG_GROUP_NAME=/aws/lambda/test-service-test-test-func',
+          '-e', 'AWS_REGION=us-east-1',
+          '-e', 'SERVERLESS_SIMULATE=true',
+          '-e', 'SERVERLESS_SIMULATE_STAGE=test',
+        ],
+      })
+
+      expect(actual).toEqual({
+        message: 'saved',
+      })
+    })
+  })
+
   it('should fail when errorMessage returned', () => {
     const funcConfig = {
       runtime: 'python2.7',

--- a/lib/services/index.js
+++ b/lib/services/index.js
@@ -19,6 +19,7 @@ const getError = (spawnResult) => {
 const start = (options, log) => {
   const opts = options || {}
   const file = opts.file || `${process.cwd()}/docker-compose.yml`
+  const projectName = opts.projectName
   const host = opts.host
   const spawnOptions = opts.spawnOptions || { encoding: 'utf8' }
 
@@ -29,6 +30,7 @@ const start = (options, log) => {
   const args = []
     .concat(file ? ['--file', file] : [])
     .concat(host ? ['--host', host] : [])
+    .concat(projectName ? ['--project-name', projectName] : [])
     .concat(['up', '-d'])
 
   const spawnResult = spawnSync('docker-compose', args, spawnOptions)

--- a/lib/services/index.test.js
+++ b/lib/services/index.test.js
@@ -44,4 +44,33 @@ describe('start', () => {
     ])
     expect(spawnSync.mock.calls[0][2]).toEqual({ encoding: 'utf8' })
   })
+
+  it('should spawn docker-compose with project-name', () => {
+    const opt = {
+      file: 'docker-compose.yml',
+      host: 'localhost',
+      projectName: 'testproject',
+    }
+    const log = jest.fn()
+
+    const spawnResult = {
+      status: 0,
+      stderr: '',
+    }
+
+    fs.existsSync.mockImplementation(() => true)
+    spawnSync.mockImplementation(() => spawnResult)
+
+    index.start(opt, log)
+
+    expect(spawnSync.mock.calls.length).toBe(1)
+    expect(spawnSync.mock.calls[0][0]).toBe('docker-compose')
+    expect(spawnSync.mock.calls[0][1]).toEqual([
+      '--file', 'docker-compose.yml',
+      '--host', 'localhost',
+      '--project-name', 'testproject',
+      'up', '-d',
+    ])
+    expect(spawnSync.mock.calls[0][2]).toEqual({ encoding: 'utf8' })
+  })
 })


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/gertjvr/serverless-plugin-simulate/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

When starting up services via the simulate services configuration, the docker-compose command creates its own network. Any services defined here are not visible by host to any lambda docker containers running. This patch passes the default network name along so that spawned lambda docker containers can access the network of the running services.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Add a `projectName` setting to the `serverless.yml` file that will be passed to the `docker-compose` command on `servicesStart`. Use the same `projectName` to construct the default network name for passing to the `docker run` command

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

Updated unit tests.

Please let me know if you would like additional documentation / samples for this.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES