### PR TITLE
fix serverless simulate invoke

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,12 +76,12 @@ class Simulate {
               'invoke',
             ],
             options: {
-              'dc-file': {
+              function: {
                 usage: 'Name of the function',
                 shortcut: 'f',
                 required: true,
               },
-              'dc-host': {
+              path: {
                 usage: 'Path to JSON file holding input data',
                 shortcut: 'p',
               },


### PR DESCRIPTION
## What did you implement:

Fix `serverless simulate invoke`. The parameter names were broken in 08929ff0, this sets them back to the right values.

## How did you implement it:

Set the parameter names correctly in `index.js

## How can we verify it:

- `cd` into a project
- `sls simulate invoke -f someFunction`

Before this PR, you'll get this
```
Serverless: Run function undefined...
 
  Error --------------------------------------------------
 
  Function undefined does not exist
<snip>
```

Afterward it'll run the function, and say it's name instead of undefined.

## Todos:

- [ ] Write tests - This is a bug with the CLI parser, and there aren't any tests for that. AFAICT you can't test this without actually invoking the `serverless` executable.
- [x] Write documentation (bugfixes don't need docs)
- [x] Fix linting errors
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES