### PR TITLE
Support explicitly specified artifacts e.g. fat JARs

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -7,6 +7,8 @@ const JSON_CONTENT_TYPE = 'application/json'
 const normalizeProjectName = (name) => name && name.toLowerCase().replace(/[^a-z0-9]/g, '')
 
 const getFunctionConfig = (serverless, functionName, functionConfig) => {
+  const artifact =
+        'variables' in serverless ? serverless.variables.service.package.artifact : undefined
   const servicePath = serverless.config.servicePath
   const serviceName = serverless.service.service
   const provider = serverless.service.provider
@@ -33,6 +35,7 @@ const getFunctionConfig = (serverless, functionName, functionConfig) => {
       provider.environment || {},
       functionConfig.environment || {}
     ),
+    artifact,
   })
 }
 

--- a/lib/invoke/local.js
+++ b/lib/invoke/local.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const BbPromise = require('bluebird')
+const fs = require('fs')
+const { spawnSync } = require('child_process')
 const run = require('./run')
 
 const noOp = () => (undefined)
@@ -13,6 +15,28 @@ const invoke = (func, event, lambdaEndpoint, logger) => {
   const memorySize = func.memorySize || 1024
 
   const dockerImage = func.runtime ? `lambci/lambda:${func.runtime}` : 'lambci/lambda'
+
+  let taskDir
+  // If the service has an explicitly specified artifact - probably a fat JAR
+  // for a Java project, we need to unpack it and make it available to the
+  // container.
+  if (func.artifact !== undefined) {
+    const unzippedPath = `${func.servicePath}/.sls-simulate-unzipped`
+    // Replicating mkdir -p unzippedPath
+    try {
+      fs.mkdirSync(unzippedPath)
+    } catch (err) {
+      if (!err.code === 'EEXIST') {
+        throw err
+      }
+    }
+    spawnSync('unzip', ['-uqo', func.artifact, '-d', unzippedPath])
+    taskDir = unzippedPath
+  } else {
+    // If it doesn't have one, use the service directory.
+    taskDir = func.servicePath
+  }
+
   const dockerArgs = [
     '-m', `${memorySize}M`,
   ]
@@ -59,7 +83,7 @@ const invoke = (func, event, lambdaEndpoint, logger) => {
     addEnvVars: true,
     dockerImage,
     dockerArgs,
-    taskDir: func.servicePath,
+    taskDir,
     cleanUp: true,
     returnSpawnResult: true,
   }).then((result) => {

--- a/lib/invoke/local.test.js
+++ b/lib/invoke/local.test.js
@@ -6,11 +6,18 @@ const mockRun = jest.fn()
 
 jest.mock('./run', () => mockRun)
 
+jest.mock('child_process', () => ({ spawnSync: jest.fn() }))
+const mockSpawnSync = require('child_process').spawnSync
+
+jest.mock('fs', () => ({ mkdirSync: jest.fn() }))
+const mockMkdirSync = require('fs').mkdirSync
+
 const lambdaLocal = require('./local')
+
 
 describe('local-invoke', () => {
   beforeEach(() => {
-    mockRun.mockClear()
+    [mockRun, mockSpawnSync, mockMkdirSync].map(m => m.mockClear())
   })
 
   it('should invoke run', () => {
@@ -382,5 +389,38 @@ describe('local-invoke', () => {
 
       expect(actual).toEqual(null)
     })
+  })
+
+  it('should unpack explicitly specified artifacts', () => {
+    const funcConfig = {
+      runtime: 'java8',
+      servicePath: '/test/path',
+      handler: 'foo.Handler',
+      memorySize: 512,
+      timeout: 10,
+      region: 'us-east-1',
+      environment: {},
+      stage: 'dev',
+      key: 'test-service-test-test-func',
+      artifact: '/test/artifact.jar',
+    }
+
+    const event = {}
+
+    const result = {}
+
+    mockRun.mockImplementation(() => BbPromise.resolve(result))
+
+    const lambda = lambdaLocal('http://localhost:5001')
+
+    return lambda.invoke(funcConfig, event)
+      .then(() => {
+        expect(mockSpawnSync).toHaveBeenCalledTimes(1)
+        expect(mockSpawnSync.mock.calls[0][0]).toBe('unzip')
+        expect(mockRun).toHaveBeenCalledTimes(1)
+        expect(mockRun.mock.calls[0][0].taskDir).toMatch('.sls-simulate-unzipped')
+        expect(mockMkdirSync).toHaveBeenCalledTimes(1)
+        expect(mockMkdirSync.mock.calls[0][0]).toMatch('.sls-simulate-unzipped')
+      })
   })
 })


### PR DESCRIPTION
## What did you implement:

Fixes #89.

## How did you implement it:

We check whether the `serverless.variables.service.package.artifact` variable exists. If it does, it gets attached to every function object. When a function is invoked, if the artifact variable is set, the artifact is unpacked with the `unzip` shell command to a temporary directory `.sls-simulate-unzipped`. That directory is mounted into the docker container at `/var/task`. Otherwise the project root is mounted there.

## How can we verify it:

You can pick any JVM Serverless project, whichever is easiest for you. Here's instructions for Scala/SBT
- `sls create -t aws-scala-sbt -p foo`
- Replace `serverless.yml` with this:
```yaml
service: scala-template
provider:
  name: aws
  runtime: java8
package:
  artifact: target/scala-2.12/hello.jar
functions:
  hello:
    handler: hello.ApiGatewayHandler
    events:
      - http:
          path: hello
          method: get
plugins:
  - serverless-plugin-simulate
```
- `sbt assembly` - You'll need to [have SBT installed](https://www.scala-sbt.org/download.html)
- `sls simulate apigateway`
- in another terminal `curl http://localhost:3000/hello`

You should see this:
```
Serverless: Creating event
Serverless: Invoking hello
Serverless: Invoking function hello.ApiGatewayHandler
WARNING: Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.
START RequestId: 347d188f-702f-4838-82c5-620ad9367f17 Version: $LATEST
END RequestId: 347d188f-702f-4838-82c5-620ad9367f17
REPORT RequestId: 347d188f-702f-4838-82c5-620ad9367f17	Duration: 230.17 ms	Billed Duration: 300 ms	Memory Size: 1024 MB	Max Memory Used: 24 MB	

{"statusCode":200,"body":"Go Serverless v1.0! Your function executed successfully!","headers":{"x-custom-response-header":"my custom response header value"},"base64Encoded":true}
Serverless: Mapping response
GET /hello 200 1125.335 ms - 56
```

Without this PR you'll get the error from #89.


## Todos:

- [x] Write tests
- [x] Write documentation - bugfixes don't need documentation
- [x] Fix linting errors
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES