### PR TITLE
Fix stdout handling: allow logging before JSON result object

### DIFF
--- a/lib/invoke/local.js
+++ b/lib/invoke/local.js
@@ -63,19 +63,24 @@ const invoke = (func, event, lambdaEndpoint, logger) => {
     cleanUp: true,
     returnSpawnResult: true,
   }).then((result) => {
-    try {
-      const output = result.stdout ? JSON.parse(result.stdout) : null
-
-      if (output && output.errorMessage !== null && output.errorMessage !== undefined) {
-        return BbPromise.reject(new Error(output.errorMessage))
-      }
-
-      return BbPromise.resolve(output)
-    } catch (err) {
-      log(err)
-
-      return BbPromise.reject(new Error('Error executing function'))
+    if (!result.stdout) {
+      return null
     }
+    let output
+    try {
+      // The last line of stdout must be a JSON object representing the results, but prior lines
+      // can contain debugging output.
+      const stdoutLines = result.stdout.trim().split('\n')
+      output = JSON.parse(stdoutLines[stdoutLines.length - 1])
+    } catch (err) {
+      return BbPromise.reject(new Error(`Couldn't parse lambda output as JSON: ${result.stdout}`))
+    }
+
+    if (output.errorMessage !== null && output.errorMessage !== undefined) {
+      return BbPromise.reject(new Error(output.errorMessage))
+    }
+
+    return BbPromise.resolve(output)
   })
 }
 

--- a/lib/invoke/local.test.js
+++ b/lib/invoke/local.test.js
@@ -275,11 +275,42 @@ describe('local-invoke', () => {
         ],
       })
 
-      expect(err.message).toEqual('Error executing function')
+      expect(err.message).toMatch('Couldn\'t parse lambda output as JSON:')
 
       return true
     })
     .then(handled => expect(handled).toEqual(true))
+  })
+
+  it('should pass when stdout has output before the JSON', () => {
+    const funcConfig = {
+      runtime: 'node4.3',
+      servicePath: '/test/path',
+      handler: 'index.handler',
+      memorySize: 512,
+      timeout: 10,
+      region: 'us-east-1',
+      environment: {},
+      stage: 'test',
+      key: 'test-service-test-test-func',
+    }
+    const event = {}
+
+    const result = {
+      stdout:
+`here are
+some log lines
+followed by valid JSON
+{}`,
+    }
+
+    mockRun.mockImplementation(() => BbPromise.resolve(result))
+
+    const lambda = lambdaLocal('http://localhost:5001')
+
+    return lambda
+      .invoke(funcConfig, event)
+      .then((actual) => expect(actual).toEqual({}))
   })
 
   it('should pass when no error or result have been returned', () => {


### PR DESCRIPTION
## What did you implement:

Fixes #90.

## How did you implement it:

Split stdout by lines and try to parse the last one.

## How can we verify it:

See steps to reproduce in linked issue

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES