### PR TITLE
Fix Error Propagation from run.js

### DIFF
--- a/lib/invoke/local.js
+++ b/lib/invoke/local.js
@@ -76,6 +76,20 @@ const invoke = (func, event, lambdaEndpoint, logger) => {
 
       return BbPromise.reject(new Error('Error executing function'))
     }
+  }).catch((result) => {
+    try {
+      const output = result.stdout ? JSON.parse(result.stdout) : null
+
+      if (output && output.errorMessage !== null && output.errorMessage !== undefined) {
+        return BbPromise.reject(new Error(output.errorMessage))
+      }
+
+      return BbPromise.reject(output)
+    } catch (err) {
+      log(err)
+
+      return BbPromise.reject(new Error('Error executing function'))
+    }
   })
 }
 


### PR DESCRIPTION
Fix Error Propagation from run.js when return code !== 0

## What did you implement:

When invoking a local lambda function, and return `code === 1` due to an error thrown from inside the Lambda function, `reject(result)` will be called.

This means that `output.errorMessage` will not be converted into a proper Error Object.

See: https://github.com/serverless-community-labs/serverless-plugin-simulate/blob/9579e5dabb5b8b0fb2fcdcbe747325057ec43e5e/lib/invoke/run.js#L69-L72

See: https://github.com/serverless-community-labs/serverless-plugin-simulate/blob/9579e5dabb5b8b0fb2fcdcbe747325057ec43e5e/lib/invoke/local.js#L65-L79

## How did you implement it:

Add Promise.catch()

## How can we verify it:

throw an Error inside a Lambda function that is being invoked.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Provide verification config/commands/resources
- [ ] Change ready for review message below


***Is this ready for review?:*** YES