### PR TITLE
Hold a promise until signal caught, ensuring service remains running

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,11 +218,11 @@ class Simulate {
   // Lifted from serverless-offline
   blockUntilSignal() {
     const waitForSigInt = new Promise(resolve =>
-      process.on('SIGINT', () => resolve('SIGINT')),
+      process.on('SIGINT', () => resolve('SIGINT'))
     );
 
     const waitForSigTerm = new Promise(resolve =>
-      process.on('SIGTERM', () => resolve('SIGTERM')),
+      process.on('SIGTERM', () => resolve('SIGTERM'))
     );
 
     return Promise.race([waitForSigInt, waitForSigTerm]).then(command => {

--- a/index.js
+++ b/index.js
@@ -129,28 +129,32 @@ class Simulate {
         .then(out => this.serverless.cli.consoleLog(out)),
 
       'simulate:services:start': () => BbPromise.bind(this)
-        .then(this.servicesStart),
+        .then(this.servicesStart)
+        .then(this.blockUntilSignal),
 
       'simulate:register:register': () => BbPromise.bind(this)
         .then(this.register),
 
       'simulate:lambda:start': () => BbPromise.bind(this)
         .then(this.servicesStart)
-        .then(this.lambda),
+        .then(this.lambda)
+        .then(this.blockUntilSignal),
 
       'simulate:serve:initialize': () => BbPromise.bind(this)
         .then(this.apigatewayInit),
 
       'simulate:serve:start': () => BbPromise.bind(this)
         .then(this.servicesStart)
-        .then(this.apigatewayStart),
+        .then(this.apigatewayStart)
+        .then(this.blockUntilSignal),
 
       'simulate:apigateway:initialize': () => BbPromise.bind(this)
         .then(this.apigatewayInit),
 
       'simulate:apigateway:start': () => BbPromise.bind(this)
         .then(this.servicesStart)
-        .then(this.apigatewayStart),
+        .then(this.apigatewayStart)
+        .then(this.blockUntilSignal),
     }
   }
 
@@ -209,6 +213,21 @@ class Simulate {
       const message = isObject ? JSON.stringify(msg) : msg
       this.serverless.cli.log(message)
     }
+  }
+
+  // Lifted from serverless-offline
+  blockUntilSignal() {
+    const waitForSigInt = new Promise(resolve =>
+      process.on('SIGINT', () => resolve('SIGINT')),
+    );
+
+    const waitForSigTerm = new Promise(resolve =>
+      process.on('SIGTERM', () => resolve('SIGTERM')),
+    );
+
+    return Promise.race([waitForSigInt, waitForSigTerm]).then(command => {
+      this.serverless.cli.log(`Got ${command} signal. Simulate Halting...`);
+    });
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -218,16 +218,14 @@ class Simulate {
   // Lifted from serverless-offline
   blockUntilSignal() {
     const waitForSigInt = new Promise(resolve =>
-      process.on('SIGINT', () => resolve('SIGINT'))
-    );
+      process.on('SIGINT', () => resolve('SIGINT')))
 
     const waitForSigTerm = new Promise(resolve =>
-      process.on('SIGTERM', () => resolve('SIGTERM'))
-    );
+      process.on('SIGTERM', () => resolve('SIGTERM')))
 
     return Promise.race([waitForSigInt, waitForSigTerm]).then(command => {
-      this.serverless.cli.log(`Got ${command} signal. Simulate Halting...`);
-    });
+      this.serverless.cli.log(`Got ${command} signal. Simulate Halting...`)
+    })
   }
 }
 


### PR DESCRIPTION
## What did you implement:

Closes #104

## How did you implement it:

Adds a new promise to the promise chains that handle long-running services.  That promise fulfills when an exit signal (`SIGTERM` `SIGINT`) is received.  This code is strongly inspired by similar code in serverless-offline.

## How can we verify it:

Not sure.  I couldn't figure out why the problem behavior (#104) started happening; given the fix, I'm surprised it doesn't happen more, and I expect there's something I'm missing.  I'd love to talk to someone with more expertise, maybe we can figure that out.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Provide verification config/commands/resources
- [X] Change ready for review message below

***Is this ready for review?:*** Sure?
